### PR TITLE
Fix plugin-hub check: add build=standard

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,13 +29,6 @@ dependencies {
 group = 'com.chatwidgets'
 version = '1.2.0'
 
-// Expand ${version} into version.properties so the plugin reads a single source of truth at runtime.
-processResources {
-	filesMatching('version.properties') {
-		expand(version: project.version)
-	}
-}
-
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'
 	options.release.set(11)

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,5 +1,6 @@
 displayName=Chat Widgets
 author=Proven
+build=standard
 description=Displays game and private chat messages in customizable overlay widgets.
 tags=chat,game,private,pm,message,widget,overlay,split,move,custom,customize,resizable,transparent
 plugins=com.chatwidgets.ChatWidgetPlugin

--- a/src/main/java/com/chatwidgets/ChatWidgetPlugin.java
+++ b/src/main/java/com/chatwidgets/ChatWidgetPlugin.java
@@ -71,7 +71,8 @@ public class ChatWidgetPlugin extends Plugin {
     private static final String TIMESTAMP_MIGRATED_KEY = "timestampMigratedToPerWidget";
     private static final String LEGACY_FONT_SIZE_KEY = "fontSize";
     private static final String FONT_SIZE_MIGRATED_KEY = "fontSizeMigratedToPerWidget";
-    private static final String PLUGIN_VERSION = loadPluginVersion();
+    // Keep in sync with build.gradle 'version' on each release (build=standard ignores build.gradle).
+    private static final String PLUGIN_VERSION = "1.2.0";
     private static final String LAST_UPDATE_NOTICE_VERSION_KEY = "lastUpdateNoticeVersion";
     private static final int MAX_POOL_SIZE = 200;
 
@@ -420,23 +421,6 @@ public class ChatWidgetPlugin extends Plugin {
         configManager.setConfiguration(CONFIG_GROUP, FONT_SIZE_MIGRATED_KEY, true);
     }
 
-    /** Reads the build-injected version from version.properties; null in dev / unfiltered runs. */
-    private static String loadPluginVersion() {
-        try (java.io.InputStream in = ChatWidgetPlugin.class.getResourceAsStream("/version.properties")) {
-            if (in != null) {
-                java.util.Properties props = new java.util.Properties();
-                props.load(in);
-                String v = props.getProperty("version");
-                if (v != null && !v.isEmpty() && !v.contains("$")) {
-                    return v;
-                }
-            }
-        } catch (java.io.IOException e) {
-            // fall through to null — no update notice rather than a wrong one
-        }
-        return null;
-    }
-
     /**
      * Arms the one-time "Chat Widgets has been updated" notice when the running {@link #PLUGIN_VERSION}
      * differs from the last version we announced. Suppressed on a brand-new install (nothing to
@@ -444,9 +428,6 @@ public class ChatWidgetPlugin extends Plugin {
      * logged in and the chat is ready.
      */
     private void armUpdateNotice() {
-        if (PLUGIN_VERSION == null) {
-            return;  // version unavailable (dev build) — don't fire an update notice
-        }
         if (firstRun) {
             configManager.setConfiguration(CONFIG_GROUP, LAST_UPDATE_NOTICE_VERSION_KEY, PLUGIN_VERSION);
             return;

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,1 +1,0 @@
-version=${version}


### PR DESCRIPTION
The plugin-hub packager check failed with `"build" must be set`.

- Add `build=standard` to `runelite-plugin.properties` (RuneLite's recommended, more-secure build type; no non-standard deps here).
- Since `build=standard` makes the hub ignore `build.gradle`, the `version.properties` + `processResources` version-injection can't run — reverted `PLUGIN_VERSION` to a constant kept in sync with `build.gradle`, and removed the resource + gradle customization.