### PR TITLE
feat: render RuneLite emojis in chat widget messages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ task run(type: JavaExec) {
 	description = 'Run the RuneLite client with the plugin'
 	classpath = sourceSets.test.runtimeClasspath
 	mainClass = 'com.chatwidgets.ChatWidgetPluginTest'
-	jvmArgs '-ea'
+	jvmArgs '-ea', '--add-opens=java.desktop/com.apple.eawt=ALL-UNNAMED'
 	args '--developer-mode'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,12 @@ task run(type: JavaExec) {
 	description = 'Run the RuneLite client with the plugin'
 	classpath = sourceSets.test.runtimeClasspath
 	mainClass = 'com.chatwidgets.ChatWidgetPluginTest'
-	jvmArgs '-ea', '--add-opens=java.desktop/com.apple.eawt=ALL-UNNAMED'
+	jvmArgs '-ea'
+	// macOS-only: com.apple.eawt doesn't exist on Windows/Linux JDKs, where the flag would print a
+	// JVM startup warning on every launch. jvmArgs() appends, so this adds the flag only on mac.
+	if (System.getProperty('os.name').toLowerCase().startsWith('mac')) {
+		jvmArgs '--add-opens=java.desktop/com.apple.eawt=ALL-UNNAMED'
+	}
 	args '--developer-mode'
 }
 

--- a/src/main/java/com/chatwidgets/ChatWidgetPlugin.java
+++ b/src/main/java/com/chatwidgets/ChatWidgetPlugin.java
@@ -35,6 +35,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.plugins.chatfilter.ChatFilterConfig;
 import net.runelite.client.plugins.chatfilter.ChatFilterPlugin;
+import net.runelite.client.plugins.emojis.EmojiPlugin;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.components.colorpicker.ColorPickerManager;
@@ -51,6 +52,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 
 /**
@@ -180,6 +182,7 @@ public class ChatWidgetPlugin extends Plugin {
     // Mirrors the Chat Filter plugin's word/regex lists when "Use Chat Filter" is enabled
     private final ChatMessageFilter chatMessageFilter = new ChatMessageFilter();
     private Plugin chatFilterPlugin;
+    private Plugin emojiPlugin;
 
     // Dynamic overlays
     private final List<OverlayConfig> overlayConfigs = new ArrayList<>();
@@ -191,34 +194,44 @@ public class ChatWidgetPlugin extends Plugin {
     private boolean firstRun = false;
     private boolean updateNoticePending = false;
 
-    // Chat command support — track messages that may be updated by Chat Commands plugin
-    private final List<PendingChatCommand> pendingCommands = new ArrayList<>();
+    // Messages whose backing MessageNode may be rewritten in place by another plugin after we
+    // capture it — Chat Commands (command results) or the RuneLite Emojis plugin (<img=N> tags).
+    // Drained on subsequent game ticks by reconcilePendingUpdates().
+    private final List<PendingMessageUpdate> pendingUpdates = new ArrayList<>();
 
-    // Emoji support — one-shot watch list drained on the next tick to pick up <img=N> tags the
-    // RuneLite Emojis plugin writes to the message node during chat event dispatch.
-    private final List<PendingEmojiMessage> pendingEmojiMessages = new ArrayList<>();
+    // The Chat Commands plugin rewrites a command's result into the RuneLite-format message; it can
+    // take several ticks to arrive, so command entries linger until then.
+    private static final int COMMAND_UPDATE_TICKS = 10;
+    private static final Function<MessageNode, String> COMMAND_VALUE = MessageNode::getRuneLiteFormatMessage;
 
-    private static class PendingChatCommand {
+    // The Emojis plugin converts shortcuts to <img=N> synchronously within the same dispatch, so a
+    // single follow-up tick suffices before the entry is dropped.
+    private static final int EMOJI_UPDATE_TICKS = 1;
+    private static final Function<MessageNode, String> EMOJI_VALUE = node -> {
+        String value = node.getValue();
+        return value == null ? null : value.trim();
+    };
+
+    /**
+     * A pooled message whose backing {@link MessageNode} may be rewritten in place by another
+     * plugin after capture. Reconciled on subsequent ticks by {@link #reconcilePendingUpdates()}:
+     * once {@code valueAccessor} reports a value different from {@code originalText}, the pooled
+     * message is rebuilt with it; the entry is dropped when it updates or after its tick budget.
+     */
+    private static class PendingMessageUpdate {
         final WidgetMessage widgetMessage;
         final MessageNode messageNode;
+        final Function<MessageNode, String> valueAccessor;
         final String originalText;
         int ticksRemaining;
 
-        PendingChatCommand(WidgetMessage widgetMessage, MessageNode messageNode, String originalText) {
+        PendingMessageUpdate(WidgetMessage widgetMessage, MessageNode messageNode,
+                Function<MessageNode, String> valueAccessor, String originalText, int ticksRemaining) {
             this.widgetMessage = widgetMessage;
             this.messageNode = messageNode;
+            this.valueAccessor = valueAccessor;
             this.originalText = originalText;
-            this.ticksRemaining = 10;
-        }
-    }
-
-    private static class PendingEmojiMessage {
-        final WidgetMessage widgetMessage;
-        final MessageNode messageNode;
-
-        PendingEmojiMessage(WidgetMessage widgetMessage, MessageNode messageNode) {
-            this.widgetMessage = widgetMessage;
-            this.messageNode = messageNode;
+            this.ticksRemaining = ticksRemaining;
         }
     }
 
@@ -260,8 +273,7 @@ public class ChatWidgetPlugin extends Plugin {
             overlayManager.remove(overlay);
         }
         overlays.clear();
-        pendingCommands.clear();
-        pendingEmojiMessages.clear();
+        pendingUpdates.clear();
 
         if (pmWidgetsHidden) {
             setPmWidgetsHidden(false);
@@ -583,11 +595,16 @@ public class ChatWidgetPlugin extends Plugin {
 
         // Emoji support: for emoji-eligible types that aren't chat commands, seed the stored body
         // from the message node (mutated in place by the RuneLite Emojis plugin to insert <img=N>)
-        // rather than the immutable pre-plugin event message. Commands (message.startsWith("!"))
-        // stay on the pendingCommands path below. Reconciled on the next tick in onGameTick, which
-        // catches the case where Emojis is registered after us and hasn't converted yet at capture.
+        // rather than the immutable pre-plugin event message. Gated on the Emojis plugin being
+        // enabled so we only switch capture source when there's a reason to — otherwise an unrelated
+        // plugin's in-place node edit (e.g. Chat Filter censoring) could leak into what we store.
+        // Commands (message.startsWith("!")) stay on the command path below. Reconciled on the next
+        // tick in onGameTick, catching the case where Emojis is registered after us and hasn't
+        // converted yet at capture.
         MessageNode messageNode = event.getMessageNode();
-        boolean emojiWatched = EMOJI_WATCHED_TYPES.contains(type) && !message.startsWith("!");
+        boolean emojiWatched = EMOJI_WATCHED_TYPES.contains(type)
+                && !message.startsWith("!")
+                && isEmojiPluginEnabled();
         if (emojiWatched && messageNode != null) {
             String nodeValue = messageNode.getValue();
             if (nodeValue != null && !nodeValue.trim().isEmpty()) {
@@ -679,9 +696,11 @@ public class ChatWidgetPlugin extends Plugin {
         // Track potential chat commands for delayed updates by Chat Commands plugin; otherwise
         // watch emoji-eligible messages for the Emojis plugin's next-tick <img=N> conversion.
         if (messageNode != null && message.startsWith("!")) {
-            pendingCommands.add(new PendingChatCommand(newMsg, messageNode, message));
+            pendingUpdates.add(new PendingMessageUpdate(
+                    newMsg, messageNode, COMMAND_VALUE, message, COMMAND_UPDATE_TICKS));
         } else if (emojiWatched && messageNode != null) {
-            pendingEmojiMessages.add(new PendingEmojiMessage(newMsg, messageNode));
+            pendingUpdates.add(new PendingMessageUpdate(
+                    newMsg, messageNode, EMOJI_VALUE, message, EMOJI_UPDATE_TICKS));
         }
     }
 
@@ -695,78 +714,74 @@ public class ChatWidgetPlugin extends Plugin {
             configManager.setConfiguration(CONFIG_GROUP, LAST_UPDATE_NOTICE_VERSION_KEY, PLUGIN_VERSION);
         }
 
-        reconcilePendingEmojiMessages();
+        reconcilePendingUpdates();
+    }
 
-        if (pendingCommands.isEmpty()) {
-            return;
-        }
-
-        for (int i = pendingCommands.size() - 1; i >= 0; i--) {
-            PendingChatCommand pending = pendingCommands.get(i);
+    /**
+     * Drains {@link #pendingUpdates}, rebuilding any pooled message whose backing node has been
+     * rewritten since capture (Chat Commands results, Emojis {@code <img=N>} tags). Each entry is
+     * dropped once its value changes and the message is rebuilt, or once its tick budget runs out.
+     */
+    private void reconcilePendingUpdates() {
+        for (int i = pendingUpdates.size() - 1; i >= 0; i--) {
+            PendingMessageUpdate pending = pendingUpdates.get(i);
             pending.ticksRemaining--;
 
-            String currentValue = pending.messageNode.getRuneLiteFormatMessage();
+            String currentValue = pending.valueAccessor.apply(pending.messageNode);
             if (currentValue != null && !currentValue.equals(pending.originalText)) {
-                int idx = messages.indexOf(pending.widgetMessage);
-                if (idx >= 0) {
-                    WidgetMessage old = pending.widgetMessage;
-                    WidgetMessage updated;
-                    if (old.getSender() != null) {
-                        updated = WidgetMessage.senderMessage(
-                                old.getSender(), old.getChannelName(), currentValue,
-                                old.getTimestamp(), old.getType(), old.isOutgoing());
-                    } else {
-                        updated = WidgetMessage.gameMessage(
-                                currentValue, old.getTimestamp(), old.getType(), old.isBossKc());
-                    }
-                    if (old.getCount() > 1) {
-                        updated.setCount(old.getCount());
-                    }
-                    messages.set(idx, updated);
-                }
-                pendingCommands.remove(i);
+                rebuildPooledMessage(pending.widgetMessage, currentValue);
+                pendingUpdates.remove(i);
             } else if (pending.ticksRemaining <= 0) {
-                pendingCommands.remove(i);
+                pendingUpdates.remove(i);
             }
         }
     }
 
     /**
-     * Drains the one-shot emoji watch list, rebuilding any captured message whose node value has
-     * changed since capture. The RuneLite Emojis plugin converts shortcuts (e.g. {@code :)}) to
-     * {@code <img=N>} by mutating the {@link MessageNode} during chat event dispatch. When it is
-     * registered after us, the node is still unconverted when we capture in {@link #onChatMessage};
-     * because that conversion is synchronous within the dispatch, the node holds its final value by
-     * the next game tick, so a single follow-up tick suffices. Every entry is dropped after this
-     * pass regardless — the emoji path is the sole writer of any body it watches.
+     * Replaces the pooled {@code old} message with a copy carrying {@code newBody}, preserving its
+     * kind (sender vs game), count, and metadata. Re-applies duplicate collapsing afterwards: the
+     * body only reaches its final form here (a command result, or an Emojis {@code <img=N>} tag),
+     * so a duplicate the capture-time text couldn't match may only surface post-rewrite. No-op if
+     * {@code old} has already been evicted from the pool.
      */
-    private void reconcilePendingEmojiMessages() {
-        if (pendingEmojiMessages.isEmpty()) {
+    private void rebuildPooledMessage(WidgetMessage old, String newBody) {
+        int idx = messages.indexOf(old);
+        if (idx < 0) {
             return;
         }
-        for (PendingEmojiMessage pending : pendingEmojiMessages) {
-            String currentValue = pending.messageNode.getValue();
-            if (currentValue == null) {
-                continue;
-            }
-            currentValue = currentValue.trim();
-            WidgetMessage old = pending.widgetMessage;
-            if (currentValue.equals(old.getMessage())) {
-                continue;
-            }
-            int idx = messages.indexOf(old);
-            if (idx < 0) {
-                continue;
-            }
-            WidgetMessage updated = WidgetMessage.senderMessage(
-                    old.getSender(), old.getChannelName(), currentValue,
+        WidgetMessage updated;
+        if (old.getSender() != null) {
+            updated = WidgetMessage.senderMessage(
+                    old.getSender(), old.getChannelName(), newBody,
                     old.getTimestamp(), old.getType(), old.isOutgoing());
-            if (old.getCount() > 1) {
-                updated.setCount(old.getCount());
-            }
-            messages.set(idx, updated);
+        } else {
+            updated = WidgetMessage.gameMessage(newBody, old.getTimestamp(), old.getType(), old.isBossKc());
         }
-        pendingEmojiMessages.clear();
+        if (old.getCount() > 1) {
+            updated.setCount(old.getCount());
+        }
+        messages.set(idx, updated);
+
+        // The shortcut-vs-<img> (or command-vs-result) mismatch at capture time can hide a
+        // duplicate that only matches once the body reaches its final form here. count values
+        // already include their own occurrences, so combine with no +1 — matching onChatMessage.
+        if (config.collapseDuplicates() && updated.getType() != ChatMessageType.LOGINLOGOUTNOTIFICATION) {
+            String strippedNew = stripTags(newBody);
+            String newSender = updated.getSender();
+            for (int i = messages.size() - 1; i >= 0; i--) {
+                if (i == idx) {
+                    continue;
+                }
+                WidgetMessage other = messages.get(i);
+                String otherSender = other.getSender();
+                if (stripTags(other.getMessage()).equals(strippedNew)
+                        && (otherSender == null ? newSender == null : otherSender.equals(newSender))) {
+                    updated.setCount(updated.getCount() + other.getCount());
+                    messages.remove(i);
+                    break;
+                }
+            }
+        }
     }
 
     @Subscribe
@@ -811,6 +826,24 @@ public class ChatWidgetPlugin extends Plugin {
             }
         }
         return chatFilterPlugin != null && pluginManager.isPluginEnabled(chatFilterPlugin);
+    }
+
+    /**
+     * True when RuneLite's Emojis plugin is currently enabled. Only then do we seed captured bodies
+     * from the live message node (and watch for its {@code <img=N>} rewrite); otherwise we keep the
+     * raw event message so an unrelated plugin's in-place node edit (e.g. Chat Filter censoring)
+     * can't silently change what we store and render.
+     */
+    private boolean isEmojiPluginEnabled() {
+        if (emojiPlugin == null) {
+            for (Plugin p : pluginManager.getPlugins()) {
+                if (p instanceof EmojiPlugin) {
+                    emojiPlugin = p;
+                    break;
+                }
+            }
+        }
+        return emojiPlugin != null && pluginManager.isPluginEnabled(emojiPlugin);
     }
 
     // --- Message access for overlays ---

--- a/src/main/java/com/chatwidgets/ChatWidgetPlugin.java
+++ b/src/main/java/com/chatwidgets/ChatWidgetPlugin.java
@@ -671,20 +671,10 @@ public class ChatWidgetPlugin extends Plugin {
             newMsg = WidgetMessage.gameMessage(message, System.currentTimeMillis(), type, isBossKc);
         }
 
-        // Collapse duplicates (except login notifications)
+        // Collapse duplicates (except login notifications). newMsg isn't in the pool yet, so pass
+        // skipIndex -1 and base count 1 — the fold adds the matched entry's own count on top.
         if (config.collapseDuplicates() && type != ChatMessageType.LOGINLOGOUTNOTIFICATION) {
-            String strippedNew = stripTags(message);
-            for (int i = messages.size() - 1; i >= 0; i--) {
-                WidgetMessage existing = messages.get(i);
-                String existingSender = existing.getSender();
-                String newSender = newMsg.getSender();
-                if (stripTags(existing.getMessage()).equals(strippedNew)
-                        && (existingSender == null ? newSender == null : existingSender.equals(newSender))) {
-                    newMsg.setCount(existing.getCount() + 1);
-                    messages.remove(i);
-                    break;
-                }
-            }
+            newMsg.setCount(collapseDuplicate(messages, stripTags(message), newMsg.getSender(), 1, -1));
         }
 
         messages.add(newMsg);
@@ -763,24 +753,11 @@ public class ChatWidgetPlugin extends Plugin {
         messages.set(idx, updated);
 
         // The shortcut-vs-<img> (or command-vs-result) mismatch at capture time can hide a
-        // duplicate that only matches once the body reaches its final form here. count values
-        // already include their own occurrences, so combine with no +1 — matching onChatMessage.
+        // duplicate that only matches once the body reaches its final form here. updated is already
+        // in the pool, so skip its own slot and fold on top of the count it already carries.
         if (config.collapseDuplicates() && updated.getType() != ChatMessageType.LOGINLOGOUTNOTIFICATION) {
-            String strippedNew = stripTags(newBody);
-            String newSender = updated.getSender();
-            for (int i = messages.size() - 1; i >= 0; i--) {
-                if (i == idx) {
-                    continue;
-                }
-                WidgetMessage other = messages.get(i);
-                String otherSender = other.getSender();
-                if (stripTags(other.getMessage()).equals(strippedNew)
-                        && (otherSender == null ? newSender == null : otherSender.equals(newSender))) {
-                    updated.setCount(updated.getCount() + other.getCount());
-                    messages.remove(i);
-                    break;
-                }
-            }
+            updated.setCount(collapseDuplicate(
+                    messages, stripTags(newBody), updated.getSender(), updated.getCount(), idx));
         }
     }
 
@@ -929,11 +906,42 @@ public class ChatWidgetPlugin extends Plugin {
         return null;
     }
 
-    private String stripTags(String text) {
+    private static String stripTags(String text) {
         if (text == null) {
             return "";
         }
         return text.replaceAll("</?col[^>]*>", "");
+    }
+
+    /**
+     * Folds a duplicate message into a target's slot: scans {@code pool} for an entry with the same
+     * colour-stripped body and sender, and on a hit removes it and returns the combined count.
+     *
+     * @param pool         the shared message pool, mutated in place (the matched entry is removed)
+     * @param strippedBody the target's body with colour tags stripped ({@link #stripTags})
+     * @param sender       the target's sender ({@code null} for game messages)
+     * @param baseCount    the count the target carries before folding — 1 for a freshly captured
+     *                     message, or its preserved count when rebuilt after a node rewrite
+     * @param skipIndex    the target's own index when it already lives in {@code pool} (so it isn't
+     *                     matched against itself), or -1 when it has not been added yet
+     * @return {@code baseCount} plus the matched entry's count, or {@code baseCount} unchanged when
+     *         no duplicate is found (pool left untouched)
+     */
+    static int collapseDuplicate(List<WidgetMessage> pool, String strippedBody, String sender,
+            int baseCount, int skipIndex) {
+        for (int i = pool.size() - 1; i >= 0; i--) {
+            if (i == skipIndex) {
+                continue;
+            }
+            WidgetMessage other = pool.get(i);
+            String otherSender = other.getSender();
+            if (stripTags(other.getMessage()).equals(strippedBody)
+                    && (otherSender == null ? sender == null : otherSender.equals(sender))) {
+                pool.remove(i);
+                return baseCount + other.getCount();
+            }
+        }
+        return baseCount;
     }
 
     /**

--- a/src/main/java/com/chatwidgets/ChatWidgetPlugin.java
+++ b/src/main/java/com/chatwidgets/ChatWidgetPlugin.java
@@ -100,6 +100,25 @@ public class ChatWidgetPlugin extends Plugin {
             ChatMessageType.CLAN_GIM_CHAT
     );
 
+    /**
+     * Chat types the RuneLite Emojis plugin converts (mirrors its own gate in EmojiPlugin). For
+     * these we seed the stored body from the live message node instead of the immutable event
+     * message snapshot, so emoji {@code <img=N>} tags inserted by that plugin reach our widgets.
+     * All nine are also {@link #SENDER_TYPES}, so reconciliation rebuilds via
+     * {@link WidgetMessage#senderMessage}.
+     */
+    private static final Set<ChatMessageType> EMOJI_WATCHED_TYPES = EnumSet.of(
+            ChatMessageType.PUBLICCHAT,
+            ChatMessageType.MODCHAT,
+            ChatMessageType.FRIENDSCHAT,
+            ChatMessageType.CLAN_CHAT,
+            ChatMessageType.CLAN_GUEST_CHAT,
+            ChatMessageType.CLAN_GIM_CHAT,
+            ChatMessageType.PRIVATECHAT,
+            ChatMessageType.PRIVATECHATOUT,
+            ChatMessageType.MODPRIVATECHAT
+    );
+
     /** All message types the plugin will capture into the shared pool. */
     private static final Set<ChatMessageType> ALL_SUPPORTED_TYPES = EnumSet.of(
             // Game
@@ -175,6 +194,10 @@ public class ChatWidgetPlugin extends Plugin {
     // Chat command support — track messages that may be updated by Chat Commands plugin
     private final List<PendingChatCommand> pendingCommands = new ArrayList<>();
 
+    // Emoji support — one-shot watch list drained on the next tick to pick up <img=N> tags the
+    // RuneLite Emojis plugin writes to the message node during chat event dispatch.
+    private final List<PendingEmojiMessage> pendingEmojiMessages = new ArrayList<>();
+
     private static class PendingChatCommand {
         final WidgetMessage widgetMessage;
         final MessageNode messageNode;
@@ -186,6 +209,16 @@ public class ChatWidgetPlugin extends Plugin {
             this.messageNode = messageNode;
             this.originalText = originalText;
             this.ticksRemaining = 10;
+        }
+    }
+
+    private static class PendingEmojiMessage {
+        final WidgetMessage widgetMessage;
+        final MessageNode messageNode;
+
+        PendingEmojiMessage(WidgetMessage widgetMessage, MessageNode messageNode) {
+            this.widgetMessage = widgetMessage;
+            this.messageNode = messageNode;
         }
     }
 
@@ -228,6 +261,7 @@ public class ChatWidgetPlugin extends Plugin {
         }
         overlays.clear();
         pendingCommands.clear();
+        pendingEmojiMessages.clear();
 
         if (pmWidgetsHidden) {
             setPmWidgetsHidden(false);
@@ -547,6 +581,20 @@ public class ChatWidgetPlugin extends Plugin {
         }
         message = message.trim();
 
+        // Emoji support: for emoji-eligible types that aren't chat commands, seed the stored body
+        // from the message node (mutated in place by the RuneLite Emojis plugin to insert <img=N>)
+        // rather than the immutable pre-plugin event message. Commands (message.startsWith("!"))
+        // stay on the pendingCommands path below. Reconciled on the next tick in onGameTick, which
+        // catches the case where Emojis is registered after us and hasn't converted yet at capture.
+        MessageNode messageNode = event.getMessageNode();
+        boolean emojiWatched = EMOJI_WATCHED_TYPES.contains(type) && !message.startsWith("!");
+        if (emojiWatched && messageNode != null) {
+            String nodeValue = messageNode.getValue();
+            if (nodeValue != null && !nodeValue.trim().isEmpty()) {
+                message = nodeValue.trim();
+            }
+        }
+
         // Drop messages matching the Chat Filter plugin's lists — only while that plugin is enabled.
         if (config.useChatFilter() && isChatFilterEnabled() && chatMessageFilter.matches(message)) {
             return;
@@ -628,10 +676,12 @@ public class ChatWidgetPlugin extends Plugin {
             messages.remove(0);
         }
 
-        // Track potential chat commands for delayed updates by Chat Commands plugin
-        MessageNode messageNode = event.getMessageNode();
+        // Track potential chat commands for delayed updates by Chat Commands plugin; otherwise
+        // watch emoji-eligible messages for the Emojis plugin's next-tick <img=N> conversion.
         if (messageNode != null && message.startsWith("!")) {
             pendingCommands.add(new PendingChatCommand(newMsg, messageNode, message));
+        } else if (emojiWatched && messageNode != null) {
+            pendingEmojiMessages.add(new PendingEmojiMessage(newMsg, messageNode));
         }
     }
 
@@ -644,6 +694,8 @@ public class ChatWidgetPlugin extends Plugin {
                             + " — new per-widget Font Size, Timestamps & Input Preview; Game and Clan are now separate message types. See the side panel!</col>", null);
             configManager.setConfiguration(CONFIG_GROUP, LAST_UPDATE_NOTICE_VERSION_KEY, PLUGIN_VERSION);
         }
+
+        reconcilePendingEmojiMessages();
 
         if (pendingCommands.isEmpty()) {
             return;
@@ -677,6 +729,44 @@ public class ChatWidgetPlugin extends Plugin {
                 pendingCommands.remove(i);
             }
         }
+    }
+
+    /**
+     * Drains the one-shot emoji watch list, rebuilding any captured message whose node value has
+     * changed since capture. The RuneLite Emojis plugin converts shortcuts (e.g. {@code :)}) to
+     * {@code <img=N>} by mutating the {@link MessageNode} during chat event dispatch. When it is
+     * registered after us, the node is still unconverted when we capture in {@link #onChatMessage};
+     * because that conversion is synchronous within the dispatch, the node holds its final value by
+     * the next game tick, so a single follow-up tick suffices. Every entry is dropped after this
+     * pass regardless — the emoji path is the sole writer of any body it watches.
+     */
+    private void reconcilePendingEmojiMessages() {
+        if (pendingEmojiMessages.isEmpty()) {
+            return;
+        }
+        for (PendingEmojiMessage pending : pendingEmojiMessages) {
+            String currentValue = pending.messageNode.getValue();
+            if (currentValue == null) {
+                continue;
+            }
+            currentValue = currentValue.trim();
+            WidgetMessage old = pending.widgetMessage;
+            if (currentValue.equals(old.getMessage())) {
+                continue;
+            }
+            int idx = messages.indexOf(old);
+            if (idx < 0) {
+                continue;
+            }
+            WidgetMessage updated = WidgetMessage.senderMessage(
+                    old.getSender(), old.getChannelName(), currentValue,
+                    old.getTimestamp(), old.getType(), old.isOutgoing());
+            if (old.getCount() > 1) {
+                updated.setCount(old.getCount());
+            }
+            messages.set(idx, updated);
+        }
+        pendingEmojiMessages.clear();
     }
 
     @Subscribe

--- a/src/test/java/com/chatwidgets/CollapseDuplicateTest.java
+++ b/src/test/java/com/chatwidgets/CollapseDuplicateTest.java
@@ -1,0 +1,144 @@
+package com.chatwidgets;
+
+import com.chatwidgets.model.WidgetMessage;
+import net.runelite.api.ChatMessageType;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Unit tests for {@link ChatWidgetPlugin#collapseDuplicate}, the shared duplicate-collapse used by
+ * both capture-time collapsing ({@code onChatMessage}) and post-rewrite rebuilds
+ * ({@code rebuildPooledMessage}). The helper is pure list logic over {@link WidgetMessage}, so it
+ * needs no injected RuneLite services.
+ */
+public class CollapseDuplicateTest {
+
+    private static WidgetMessage sender(String name, String body) {
+        return sender(name, body, 1);
+    }
+
+    private static WidgetMessage sender(String name, String body, int count) {
+        WidgetMessage m = WidgetMessage.senderMessage(name, null, body, 0L, ChatMessageType.PUBLICCHAT, false);
+        m.setCount(count);
+        return m;
+    }
+
+    private static WidgetMessage game(String body, int count) {
+        WidgetMessage m = WidgetMessage.gameMessage(body, 0L, ChatMessageType.GAMEMESSAGE, false);
+        m.setCount(count);
+        return m;
+    }
+
+    /**
+     * The comment-1 regression: two same-sender emoji lines that only match once both are rewritten
+     * to {@code <img=N>}. The target is already in the pool, so its own slot is skipped and the
+     * earlier duplicate is folded in — one line with count 2 instead of two identical lines.
+     */
+    @Test
+    public void postRewriteFoldsDuplicateSurfacingAfterRewrite() {
+        WidgetMessage msg1 = sender("Bob", "gg <img=29>");
+        WidgetMessage msg2 = sender("Bob", "gg <img=29>");
+        List<WidgetMessage> pool = new ArrayList<>();
+        pool.add(msg1);
+        pool.add(msg2);
+
+        int count = ChatWidgetPlugin.collapseDuplicate(pool, "gg <img=29>", "Bob", msg2.getCount(), 1);
+
+        assertEquals(2, count);
+        assertEquals(1, pool.size());
+        assertSame("target keeps its slot; the earlier duplicate is removed", msg2, pool.get(0));
+    }
+
+    /** Capture-time semantics: target not yet in the pool (skipIndex -1), base 1, folds the match. */
+    @Test
+    public void captureTimeFoldsDuplicateOnTopOfBaseOne() {
+        List<WidgetMessage> pool = new ArrayList<>();
+        pool.add(sender("Bob", "gg"));
+
+        int count = ChatWidgetPlugin.collapseDuplicate(pool, "gg", "Bob", 1, -1);
+
+        assertEquals(2, count);
+        assertEquals(0, pool.size());
+    }
+
+    /** A matched entry that already carries a count is added on top, not replaced by 1. */
+    @Test
+    public void foldsExistingCountOnTopOfBase() {
+        List<WidgetMessage> pool = new ArrayList<>();
+        pool.add(sender("Bob", "gg", 3));
+
+        int count = ChatWidgetPlugin.collapseDuplicate(pool, "gg", "Bob", 1, -1);
+
+        assertEquals(4, count);
+        assertEquals(0, pool.size());
+    }
+
+    /** On a rewrite the target's preserved count is the base folded on top of the match. */
+    @Test
+    public void foldsPreservedTargetCountOnRewrite() {
+        WidgetMessage other = sender("Bob", "gg", 4);
+        WidgetMessage target = sender("Bob", "gg", 2);
+        List<WidgetMessage> pool = new ArrayList<>();
+        pool.add(other);
+        pool.add(target);
+
+        int count = ChatWidgetPlugin.collapseDuplicate(pool, "gg", "Bob", target.getCount(), 1);
+
+        assertEquals(6, count);
+        assertEquals(1, pool.size());
+        assertSame(target, pool.get(0));
+    }
+
+    /** Same body but a different sender is not a duplicate — no fold, pool untouched. */
+    @Test
+    public void differentSenderDoesNotCollapse() {
+        List<WidgetMessage> pool = new ArrayList<>();
+        pool.add(sender("Alice", "gg"));
+
+        int count = ChatWidgetPlugin.collapseDuplicate(pool, "gg", "Bob", 1, -1);
+
+        assertEquals(1, count);
+        assertEquals(1, pool.size());
+    }
+
+    /** No match returns the base count unchanged and leaves the pool alone. */
+    @Test
+    public void noMatchReturnsBaseAndLeavesPool() {
+        List<WidgetMessage> pool = new ArrayList<>();
+        pool.add(sender("Bob", "hi"));
+
+        int count = ChatWidgetPlugin.collapseDuplicate(pool, "bye", "Bob", 5, -1);
+
+        assertEquals(5, count);
+        assertEquals(1, pool.size());
+    }
+
+    /** Game messages have a null sender; two nulls collapse as equal. */
+    @Test
+    public void nullSendersCollapseAsGameMessages() {
+        List<WidgetMessage> pool = new ArrayList<>();
+        pool.add(game("You gained some XP.", 1));
+
+        int count = ChatWidgetPlugin.collapseDuplicate(pool, "You gained some XP.", null, 1, -1);
+
+        assertEquals(2, count);
+        assertEquals(0, pool.size());
+    }
+
+    /** Colour tags are stripped from pool entries before comparison. */
+    @Test
+    public void colourTagsStrippedBeforeCompare() {
+        List<WidgetMessage> pool = new ArrayList<>();
+        pool.add(sender("Bob", "<col=ff0000>gg</col>"));
+
+        int count = ChatWidgetPlugin.collapseDuplicate(pool, "gg", "Bob", 1, -1);
+
+        assertEquals(2, count);
+        assertEquals(0, pool.size());
+    }
+}


### PR DESCRIPTION
## What

Resolves #22 

Chat widgets now render RuneLite emojis (`:)` → 😀, `--o` → 🥄, etc.) in message bodies for public, private, clan, and friends-chat channels, matching the in-game chatbox.

## Why

`onChatMessage` stored `event.getMessage()`, an immutable pre-plugin snapshot. The RuneLite Emojis plugin converts shortcuts to `<img=N>` tags by mutating the `MessageNode` in place (`setValue`), never touching the event's message field, so the captured text could never contain the emoji tag. Rendering already supports `<img=N>` (`parseTextWithColoursAndIcons` + `getModIconImage`), so the gap was purely the captured body.

## How

Single behavioural change, isolated to `ChatWidgetPlugin.java`:

- **Capture:** for the nine emoji-eligible chat types (excluding `!`-prefixed chat commands, which keep their existing `pendingCommands` path), seed the stored body from `messageNode.getValue()` instead of the event snapshot. Handles the case where Emojis ran before us with no `:)` flash.
- **Reconcile:** enqueue each captured message on a one-shot watch list, drained on the next `onGameTick`. If the node value changed (Emojis registered after us, converting later in the same synchronous dispatch), rebuild the `WidgetMessage` with the new body, carrying `count` forward. Every entry is dropped after one tick.

Rendering, model, and config are untouched. No config toggle: emojis render whenever the Emojis plugin is enabled, mirroring the chatbox.

## Trade-offs / notes

- Depends on the RuneLite Emojis plugin; emojis render only when it is enabled.
- Accepted edge case: with `collapseDuplicates` on, spaced duplicate emoji messages may fail to collapse under the unfavourable plugin-registration order (two lines instead of a `(2)` count). Benign.
- Includes a small macOS-only `build.gradle` tweak (`--add-opens=java.desktop/com.apple.eawt`) so `./gradlew run` launches under a modular JDK.

## Verification

Manual, in-client (`./gradlew run` with Emojis + Chat Widgets enabled): `:)` / `:heart:` render across public, clan, and PM; a repeated emoji message keeps its `(N)`; a `!kc` command still updates via the untouched command path.