### PR TITLE
feat: per-widget Margin Left and Margin Right

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # Chat Widgets
 
-**Version 1.2.0**
+**Version 1.2.1**
 
 Create custom chat widgets that display any combination of message types. Each widget is independently configurable with its own message filters, positioning, fade behaviour, and more. Manage widgets from the sidebar panel — add, remove, reorder, and configure as many as you need.
+
+## What's New
+
+- New per-widget settings: Margin Left, Margin Right
+- Emoji support
 
 ## Examples
 
@@ -68,6 +73,8 @@ Each widget is configured independently from the sidebar panel.
 | **Dynamic Height**       | Widget height adjusts based on message count rather than using fixed height. Disable this if you notice a subtle jitter effect when Fade Out is enabled.                                        |
 | **Margin Top**           | Extra spacing above the widget (0–200).                                                                                                                                                         |
 | **Margin Bottom**        | Extra spacing below the widget (0–200).                                                                                                                                                         |
+| **Margin Left**          | Extra spacing to the left of the widget (0–200).                                                                                                                                                |
+| **Margin Right**         | Extra spacing to the right of the widget (0–200).                                                                                                                                               |
 
 ## Tips
 

--- a/src/main/java/com/chatwidgets/ChatWidgetPanel.java
+++ b/src/main/java/com/chatwidgets/ChatWidgetPanel.java
@@ -259,6 +259,14 @@ public class ChatWidgetPanel extends PluginPanel {
             oc.setMarginBottom(v);
             plugin.onOverlayConfigChanged();
         }));
+        content.add(buildSpinnerRow("Margin Left", oc.getMarginLeft(), 0, 200, v -> {
+            oc.setMarginLeft(v);
+            plugin.onOverlayConfigChanged();
+        }));
+        content.add(buildSpinnerRow("Margin Right", oc.getMarginRight(), 0, 200, v -> {
+            oc.setMarginRight(v);
+            plugin.onOverlayConfigChanged();
+        }));
 
         // Delete button
         content.add(createStrut(6));

--- a/src/main/java/com/chatwidgets/overlay/DynamicChatOverlay.java
+++ b/src/main/java/com/chatwidgets/overlay/DynamicChatOverlay.java
@@ -165,8 +165,13 @@ public class DynamicChatOverlay extends Overlay {
 
         int marginTop = overlayConfig.getMarginTop();
         int marginBottom = overlayConfig.getMarginBottom();
+        int marginLeft = overlayConfig.getMarginLeft();
+        int marginRight = overlayConfig.getMarginRight();
 
         widgetHeight += marginTop + marginBottom + bgPadding * 2;
+        // Grow the box by the horizontal margins, mirroring widgetHeight above. Text was already
+        // wrapped at the pre-margin width, so the margins become empty space on either side.
+        widgetWidth += marginLeft + marginRight;
 
         if (followPlayer) {
             Player localPlayer = client.getLocalPlayer();
@@ -198,7 +203,7 @@ public class DynamicChatOverlay extends Overlay {
 
         if (inputSegments != null) {
             drawSegments(graphics, inputSegments, 255, y, followPlayer, widgetWidth, bgPadding,
-                    fontSize, metrics, modIcons, drawShadow);
+                    marginLeft, marginRight, fontSize, metrics, modIcons, drawShadow);
             y -= lineHeight;
         }
 
@@ -208,7 +213,7 @@ public class DynamicChatOverlay extends Overlay {
                 continue;
             }
             drawSegments(graphics, line.segments, line.alpha, y, followPlayer, widgetWidth, bgPadding,
-                    fontSize, metrics, modIcons, drawShadow);
+                    marginLeft, marginRight, fontSize, metrics, modIcons, drawShadow);
             y -= lineHeight;
         }
 
@@ -298,10 +303,14 @@ public class DynamicChatOverlay extends Overlay {
     }
 
     private void drawSegments(Graphics2D graphics, List<TextSegment> segments, int alpha, int y,
-            boolean followPlayer, int widgetWidth, int xPad, FontSize fontSize, FontMetrics metrics,
-            IndexedSprite[] modIcons, boolean drawShadow) {
+            boolean followPlayer, int widgetWidth, int xPad, int marginLeft, int marginRight,
+            FontSize fontSize, FontMetrics metrics, IndexedSprite[] modIcons, boolean drawShadow) {
         int lineWidth = calculateLineWidth(segments, metrics);
-        int x = followPlayer ? xPad + (widgetWidth - xPad * 2 - lineWidth) / 2 : xPad;
+        // Left-anchor at the left margin, or centre within the content region (box minus both
+        // margins) when following the player — mirroring how marginBottom offsets the baseline.
+        int x = followPlayer
+                ? marginLeft + xPad + (widgetWidth - marginLeft - marginRight - xPad * 2 - lineWidth) / 2
+                : xPad + marginLeft;
         for (TextSegment segment : segments) {
             if (segment.iconId >= 0) {
                 BufferedImage img = ChatRenderUtils.getModIconImage(segment.iconId, modIcons);

--- a/src/main/java/com/chatwidgets/overlay/OverlayConfig.java
+++ b/src/main/java/com/chatwidgets/overlay/OverlayConfig.java
@@ -30,6 +30,8 @@ public class OverlayConfig {
     private int widgetWidth;
     private int marginTop;
     private int marginBottom;
+    private int marginLeft;
+    private int marginRight;
     private boolean dynamicHeight;
     private boolean hideDuplicateCount;
     private boolean contextualColours;
@@ -50,6 +52,8 @@ public class OverlayConfig {
         this.widgetWidth = 512;
         this.marginTop = 0;
         this.marginBottom = 0;
+        this.marginLeft = 0;
+        this.marginRight = 0;
         this.dynamicHeight = false;
         this.hideDuplicateCount = false;
         this.contextualColours = true;
@@ -150,6 +154,22 @@ public class OverlayConfig {
 
     public void setMarginBottom(int marginBottom) {
         this.marginBottom = Math.max(0, Math.min(200, marginBottom));
+    }
+
+    public int getMarginLeft() {
+        return marginLeft;
+    }
+
+    public void setMarginLeft(int marginLeft) {
+        this.marginLeft = Math.max(0, Math.min(200, marginLeft));
+    }
+
+    public int getMarginRight() {
+        return marginRight;
+    }
+
+    public void setMarginRight(int marginRight) {
+        this.marginRight = Math.max(0, Math.min(200, marginRight));
     }
 
     public boolean isDynamicHeight() {


### PR DESCRIPTION
## What

Adds per-widget **Margin Left** and **Margin Right** spinners (0–200), completing the horizontal counterpart to the existing Margin Top/Bottom.

Closes #21

## How

Mirrors the Margin Top/Bottom implementation on the horizontal axis:

- **`OverlayConfig`** — `marginLeft` / `marginRight` fields (init 0, clamped 0–200), matching the existing margin getters/setters.
- **`ChatWidgetPanel`** — two spinner rows directly under Margin Bottom.
- **`DynamicChatOverlay`** — grows `widgetWidth` by `marginLeft + marginRight` (mirroring how `widgetHeight` grows by top+bottom), then offsets the drawn text: left-anchored at the left margin, or centred within the content region (box minus both margins) when following the player.
- **README** — two new rows in the per-widget settings table.

Like Top/Bottom, margins **grow the widget box** rather than insetting text into a fixed width — a Margin Left of 50 makes the widget 50px wider with empty space on the left and the text pushed in.

## Verification

`./gradlew compileJava` clean; verified in-client that Left/Right margins shift the widget as expected.