### PR TITLE
fix: decode <at> escape so @ renders correctly in widgets

### DIFF
--- a/src/main/java/com/chatwidgets/ChatMessageFilter.java
+++ b/src/main/java/com/chatwidgets/ChatMessageFilter.java
@@ -58,7 +58,8 @@ public class ChatMessageFilter {
         String normalized = maybeStripAccents(message
                 .replace('\u00A0', ' ')
                 .replace("<lt>", "<")
-                .replace("<gt>", ">"));
+                .replace("<gt>", ">")
+                .replace("<at>", "@"));
 
         for (Pattern pattern : patterns) {
             if (pattern.matcher(normalized).find()) {

--- a/src/main/java/com/chatwidgets/overlay/ChatRenderUtils.java
+++ b/src/main/java/com/chatwidgets/overlay/ChatRenderUtils.java
@@ -328,7 +328,7 @@ public final class ChatRenderUtils {
             return segments;
         }
 
-        text = text.replace("<lt>", "<").replace("<gt>", ">");
+        text = text.replace("<lt>", "<").replace("<gt>", ">").replace("<at>", "@");
 
         Matcher matcher = IMG_TAG_PATTERN.matcher(text);
         int lastEnd = 0;
@@ -446,6 +446,10 @@ public final class ChatRenderUtils {
                 i += 4;
             } else if (text.startsWith("<gt>", i)) {
                 currentText.append('>');
+                i += 4;
+            } else if (text.startsWith("<at>", i)) {
+                // RuneLite escapes a literal '@' as <at> so it isn't parsed as an @col@ colour code.
+                currentText.append('@');
                 i += 4;
             } else {
                 Matcher colUnknownMatcher = COL_UNKNOWN_PATTERN.matcher(text.substring(i));

--- a/src/test/java/com/chatwidgets/overlay/AtEscapeTest.java
+++ b/src/test/java/com/chatwidgets/overlay/AtEscapeTest.java
@@ -1,0 +1,78 @@
+package com.chatwidgets.overlay;
+
+import com.chatwidgets.model.FontSize;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Covers the {@code <at>} escape decode in {@link ChatRenderUtils}. RuneLite escapes a literal
+ * {@code @} as {@code <at>} in message text (so it isn't parsed as an {@code @col@} colour code);
+ * both parsers must turn it back into {@code @}, alongside the existing {@code <lt>} / {@code <gt>}
+ * decoding. The helper needs only a headless {@link FontMetrics}; no injected RuneLite services.
+ */
+public class AtEscapeTest {
+
+    private static FontMetrics metrics;
+
+    @BeforeClass
+    public static void setUp() {
+        BufferedImage img = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = img.createGraphics();
+        metrics = g.getFontMetrics(new Font(Font.SANS_SERIF, Font.PLAIN, 12));
+        g.dispose();
+    }
+
+    /** Concatenates the text of every non-icon, non-break segment. */
+    private static String textOf(List<TextSegment> segments) {
+        StringBuilder sb = new StringBuilder();
+        for (TextSegment s : segments) {
+            if (s.iconId == -1) {
+                sb.append(s.text);
+            }
+        }
+        return sb.toString();
+    }
+
+    private static String renderBody(String input) {
+        return textOf(ChatRenderUtils.parseTextWithColoursAndIcons(
+                input, metrics, null, true, Color.WHITE, FontSize.REGULAR, null));
+    }
+
+    private static String renderName(String input) {
+        return textOf(ChatRenderUtils.parseTextWithIcons(
+                input, metrics, null, Color.WHITE, FontSize.REGULAR));
+    }
+
+    /** The reported bug: "Gzzz@@@" arrives escaped as "Gzzz<at><at><at>" and rendered literally. */
+    @Test
+    public void bodyDecodesAtEscape() {
+        assertEquals("Gzzz@@@", renderBody("Gzzz<at><at><at>"));
+    }
+
+    /** The <at> decode must not regress the existing <lt> / <gt> decoding in the same parser. */
+    @Test
+    public void bodyDecodesAtAlongsideLtGt() {
+        assertEquals("a@<b>@", renderBody("a<at><lt>b<gt><at>"));
+    }
+
+    /** Sender names go through parseTextWithIcons, which also escapes literal @. */
+    @Test
+    public void nameDecodesAtEscape() {
+        assertEquals("Bob@Home", renderName("Bob<at>Home"));
+    }
+
+    /** Plain text with no escapes is unchanged. */
+    @Test
+    public void plainTextUnchanged() {
+        assertEquals("hello world", renderBody("hello world"));
+    }
+}


### PR DESCRIPTION
## Problem

Any `@` in a chat message rendered as a literal `<at>` in the widget (e.g. `Gzzz@@@` showed as `Gzzz<at><at><at>`).

RuneLite escapes a literal `@` as `<at>` in message text so it isn't parsed as an `@col@` colour code. The widget's text parsers decoded `<lt>`/`<gt>` but had **no `<at>` case**, so the escape leaked through and printed verbatim. The in-game chatbox and overhead text decode `<at>` themselves, which masked the gap.

This is **pre-existing** — it affects `event.getMessage()` directly and is independent of the emoji capture change (reproduces with the Emojis plugin disabled).

## Fix

Decode `<at>` → `@` everywhere the sibling `<lt>`/`<gt>` escapes are already handled:

- `ChatRenderUtils.parseTextWithColoursAndIcons` — message bodies (inline branch)
- `ChatRenderUtils.parseTextWithIcons` — sender names (the `.replace(...)` chain)
- `ChatMessageFilter` — normalisation, so filtered-word matching sees `@` too

## Tests

New `AtEscapeTest`:
- `Gzzz<at><at><at>` → `Gzzz@@@` (the reported case)
- `<at>` decodes alongside `<lt>`/`<gt>` in the same string (no regression)
- sender-name path decodes `<at>`
- plain text unchanged

Full suite green (`./gradlew test`).